### PR TITLE
Editorial: Use "Previous Version: from biblio"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4,7 +4,7 @@ Status: ED
 Group: WebAppSec
 ED: https://w3c.github.io/webappsec-upgrade-insecure-requests/
 TR: http://www.w3.org/TR/upgrade-insecure-requests/
-Previous Version: http://www.w3.org/TR/2015/WD-upgrade-insecure-requests-20150226/
+Previous Version: from biblio
 Shortname: upgrade-insecure-requests
 Editor: Mike West 56384, Google Inc., mkwst@google.com
 Abstract:


### PR DESCRIPTION
This change causes Bikeshed to automatically set the value of the "Previous Version" metadata/link. Otherwise, if we hardcode it, autopublishing (Echidna) fails with a "latest-is-not-previous" error saying, "Retrieved 'previous' and 'latest' documents, but their contents don't match."