### PR TITLE
Replace Mike with Carlos as the editor

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,7 +6,8 @@ ED: https://w3c.github.io/webappsec-upgrade-insecure-requests/
 TR: http://www.w3.org/TR/upgrade-insecure-requests/
 Previous Version: from biblio
 Shortname: upgrade-insecure-requests
-Editor: Mike West 56384, Google Inc., mkwst@google.com
+Editor: Carlos Joan Rafael Ibarra Lopez 117196, Google Inc., carlosil@google.com
+Former Editor: Mike West 56384, Google Inc., mkwst@google.com
 Abstract:
   This document defines a mechanism which allows authors to instruct a user
   agent to upgrade insecure resource requests to secure transport before


### PR DESCRIPTION
We talked about this in May. Does it still seem like the right thing to do? Should anyone else also be an editor?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-upgrade-insecure-requests/pull/28.html" title="Last updated on Sep 20, 2022, 12:12 AM UTC (524e8d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-upgrade-insecure-requests/28/5bf99a3...524e8d3.html" title="Last updated on Sep 20, 2022, 12:12 AM UTC (524e8d3)">Diff</a>