### PR TITLE
Flag PRs if they add warnings to the Bikeshed build

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
-          BUILD_FAIL_ON: nothing
+          BUILD_FAIL_ON: warning
           VALIDATE_LINKS: false
           VALIDATE_MARKUP: true
           W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}


### PR DESCRIPTION
The bikeshed build is already clean, so we should keep it that way.