### PR TITLE
Fix "environment settings object" URL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -50,7 +50,7 @@ spec: HTML; urlPrefix: https://html.spec.whatwg.org/multipage/
       text: creating a new document object; url: create-a-document-object
       text: nested browsing context
     urlPrefix: webappapis.html
-      text: environment settings object; url: settings-object
+      text: environment settings object
       text: incumbent settings object
       text: responsible document
       text: responsible browsing context


### PR DESCRIPTION
The explicitly given URL points to a field of scripts, rather than the concept which is intended.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Ms2ger/webappsec-upgrade-insecure-requests/pull/31.html" title="Last updated on Oct 13, 2022, 10:59 AM UTC (e14e26e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webappsec-upgrade-insecure-requests/31/1281c95...Ms2ger:e14e26e.html" title="Last updated on Oct 13, 2022, 10:59 AM UTC (e14e26e)">Diff</a>